### PR TITLE
Rename Mocks concept to Alias

### DIFF
--- a/InvokeHelperTest/private/ClientModule/ClientModule.psm1
+++ b/InvokeHelperTest/private/ClientModule/ClientModule.psm1
@@ -13,7 +13,7 @@ $CommandList =@{
 .SYNOPSIS
 Will invoke a command
 #>
-function Get-MockFunctionCall{
+function Get-FunctionCall{
     [CmdletBinding()]
     param()
 
@@ -23,13 +23,13 @@ function Get-MockFunctionCall{
     $result = Invoke-MyCommand -Command $command
 
     return $result
-} Export-ModuleMember -Function Get-MockFunctionCall
+} Export-ModuleMember -Function Get-FunctionCall
 
 <#
 .SYNOPSIS
 Will start a job with the given command.
 #>
-function Get-MockFunctionCallAsync{
+function Get-FunctionCallAsync{
     [CmdletBinding()]
     param()
 
@@ -39,4 +39,4 @@ function Get-MockFunctionCallAsync{
     $result = Invoke-MyCommandAsync -Command $command
 
     return $result
-} Export-ModuleMember -Function Get-MockFunctionCallAsync
+} Export-ModuleMember -Function Get-FunctionCallAsync

--- a/InvokeHelperTest/public/Invoke-MyCommand.test.ps1
+++ b/InvokeHelperTest/public/Invoke-MyCommand.test.ps1
@@ -24,7 +24,7 @@ function InvokeHelperTest_Invoke_MyCommand_WithMock {
     $comand = '@{login = "FakeName"; id="6666666"} | ConvertTo-Json'
 
     # Set the mock you want to use based on a CommandKey the function will use
-    Set-MockInvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
+    Set-InvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
 
     # Call the function with the CommandKey as normal
     $result = Invoke-MyCommandJson -Command 'Command to call to Mock'

--- a/InvokeHelperTest/public/Invoke-MyCommand.test.ps1
+++ b/InvokeHelperTest/public/Invoke-MyCommand.test.ps1
@@ -23,10 +23,10 @@ function InvokeHelperTest_Invoke_MyCommand_WithMock {
     # $comand = 'echo $global:test_json'
     $comand = '@{login = "FakeName"; id="6666666"} | ConvertTo-Json'
 
-    # Set the mock you want to use based on a CommandKey the function will use
-    Set-InvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
+    # Set the mock you want to use based on a Alias the function will use
+    Set-InvokeCommandAlias -Alias 'Command to call to Mock' -Command $comand
 
-    # Call the function with the CommandKey as normal
+    # Call the function with the Alias as normal
     $result = Invoke-MyCommandJson -Command 'Command to call to Mock'
 
     Assert-AreEqual -Expected 'fakeName' -Presented $result.login
@@ -67,10 +67,10 @@ function InvokeHelperTest_Invoke_MyCommand_WithParameters_WithMock {
 
     $comand = '@{login = "{name}"; id="{id}"} | ConvertTo-Json'
 
-    # Set the mock you want to use based on a CommandKey the function will use
-    Set-MockInvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
+    # Set the mock you want to use based on a Alias the function will use
+    Set-InvokeCommandAlias -Alias 'Command to call to Mock' -Command $comand
 
-    # Call the function with the CommandKey as normal
+    # Call the function with the Alias as normal
     $result = Invoke-MyCommandJson -Command 'Command to call to Mock' -Parameters $param
 
     Assert-AreEqual -Expected 'fakeName' -Presented $result.login

--- a/InvokeHelperTest/public/Invoke-MyCommandAsync.test.ps1
+++ b/InvokeHelperTest/public/Invoke-MyCommandAsync.test.ps1
@@ -23,7 +23,7 @@ function InvokeHelperTest_MyCommandAsync_Invoke_WithMock {
     $comand = '@{login = "FakeName"; id="6666666"}'
 
     # Set the mock you want to use based on a CommandKey the function will use
-    Set-MockInvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
+    Set-InvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
 
     # Call the function with the CommandKey as normal
     $result = Invoke-MyCommandAsync -Command 'Command to call to Mock'
@@ -142,7 +142,7 @@ function InvokeHelperTest_MyCommandAsync_Invoke_Multiple_StingArray_WithMock{
 
         $command = $commandPattern -replace '{number}', $_
         $commandMock = $comandMockPattern -replace '{number}', $_
-        Set-MockInvokeCommand -CommandKey $command -Command $commandMock
+        Set-InvokeCommand -CommandKey $command -Command $commandMock
 
         $commands += $command
     }

--- a/InvokeHelperTest/public/Invoke-MyCommandAsync.test.ps1
+++ b/InvokeHelperTest/public/Invoke-MyCommandAsync.test.ps1
@@ -22,10 +22,10 @@ function InvokeHelperTest_MyCommandAsync_Invoke_WithMock {
 
     $comand = '@{login = "FakeName"; id="6666666"}'
 
-    # Set the mock you want to use based on a CommandKey the function will use
-    Set-InvokeCommand -CommandKey 'Command to call to Mock' -Command $comand
+    # Set the mock you want to use based on a Alias the function will use
+    Set-InvokeCommandAlias -Alias 'Command to call to Mock' -Command $comand
 
-    # Call the function with the CommandKey as normal
+    # Call the function with the Alias as normal
     $result = Invoke-MyCommandAsync -Command 'Command to call to Mock'
 
     Assert-AreEqual -Expected 'fakeName' -Presented $result.login
@@ -142,7 +142,7 @@ function InvokeHelperTest_MyCommandAsync_Invoke_Multiple_StingArray_WithMock{
 
         $command = $commandPattern -replace '{number}', $_
         $commandMock = $comandMockPattern -replace '{number}', $_
-        Set-InvokeCommand -CommandKey $command -Command $commandMock
+        Set-InvokeCommandAlias -Alias $command -Command $commandMock
 
         $commands += $command
     }

--- a/InvokeHelperTest/public/mocked-functioncall.test.ps1
+++ b/InvokeHelperTest/public/mocked-functioncall.test.ps1
@@ -7,7 +7,7 @@ function InvokeHelperTest_MockFunctionCall{
     Import-Module -name $clientModulePath -Force
 
     # Set the mock to a valid command
-    Set-MockInvokeCommand -CommandKey 'gh api user' -Command ' echo "Hello World" '
+    Set-InvokeCommand -CommandKey 'gh api user' -Command ' echo "Hello World" '
 
     # Call the module funtion
     $result = Get-MockFunctionCall
@@ -20,7 +20,7 @@ function InvokeHelperTest_MockFunctionCallAsync{
     $clientModulePath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath private -AdditionalChildPath ClientModule
     Import-Module -name $clientModulePath -Force
 
-    Set-MockInvokeCommand -CommandKey 'gh api user' -Command ' echo "Hello World" '
+    Set-InvokeCommand -CommandKey 'gh api user' -Command ' echo "Hello World" '
 
     $result =  Get-MockFunctionCallAsync
 

--- a/InvokeHelperTest/public/mocked-functioncall.test.ps1
+++ b/InvokeHelperTest/public/mocked-functioncall.test.ps1
@@ -1,28 +1,28 @@
 # This Test will call a function on a module that calls Invoke-MyCommand with a command
 # We will mock that command to return the desired test result
 
-function InvokeHelperTest_MockFunctionCall{
+function InvokeHelperTest_FunctionCall{
     # Load de module
     $clientModulePath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath private -AdditionalChildPath ClientModule
     Import-Module -name $clientModulePath -Force
 
     # Set the mock to a valid command
-    Set-InvokeCommand -CommandKey 'gh api user' -Command ' echo "Hello World" '
+    Set-InvokeCommandAlias -Alias 'gh api user' -Command ' echo "Hello World" '
 
     # Call the module funtion
-    $result = Get-MockFunctionCall
+    $result = Get-FunctionCall
 
     # Assert to the mock result
     Assert-AreEqual -Expected "Hello World" -Presented $result
 }
 
-function InvokeHelperTest_MockFunctionCallAsync{
+function InvokeHelperTest_FunctionCallAsync{
     $clientModulePath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath private -AdditionalChildPath ClientModule
     Import-Module -name $clientModulePath -Force
 
-    Set-InvokeCommand -CommandKey 'gh api user' -Command ' echo "Hello World" '
+    Set-InvokeCommandAlias -Alias 'gh api user' -Command ' echo "Hello World" '
 
-    $result =  Get-MockFunctionCallAsync
+    $result =  Get-FunctionCallAsync
 
     Assert-AreEqual -Expected "Hello World" -Presented $result
 }

--- a/en-US/about_InvokeHelper.help.txt
+++ b/en-US/about_InvokeHelper.help.txt
@@ -29,7 +29,7 @@ SETTING THE COMMAND LIST
     To allow the decouple of the function with the app or tool to call we can set the command list for later to be used.
 
     ```powershell
-        > Set-InvokeCommand -Command "GetUser" -CommandPath "gh api user"
+        > Set-InvokeCommandAlias -Alias "GetUser" -CommandPath "gh api user"
         > $result = Invoke-MyCommandJson -Command "GetUser"
         > Assert-AreEqual -Expected 'fakeName' -Presented $result.login
         > Assert-AreEqual -Expected 6666666 -Presented $result.id

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -6,12 +6,8 @@ function Build-ScriptBlock{
         [Parameter()][hashtable]$Parameters
     )
     process {
-
-        if(Test-InvokeCommandAlias -Alias $Command){
-            $cmd = Get-InvokeCommandAlias -Alias $Command
-        } else {
-            $cmd = $Command
-        }
+        # Check if command is an alias. If not will return the command.
+        $cmd = Resolve-InvokeCommandAlias -Alias $Command
 
         # Replace parameters on command
         if($Parameters){
@@ -25,3 +21,4 @@ function Build-ScriptBlock{
         return $ScriptBlock
     }
 }
+

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -7,8 +7,8 @@ function Build-ScriptBlock{
     )
     process {
 
-        if(Test-MockInvokeCommand -Command $Command){
-            $cmd = Get-MockInvokeCommand -Command $Command
+        if(Test-InvokeCommand -Command $Command){
+            $cmd = Get-InvokeCommand -Command $Command
         } else {
             $cmd = $Command
         }

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -7,8 +7,8 @@ function Build-ScriptBlock{
     )
     process {
 
-        if(Test-InvokeCommand -Command $Command){
-            $cmd = Get-InvokeCommand -Command $Command
+        if(Test-InvokeCommandAlias -Alias $Command){
+            $cmd = Get-InvokeCommandAlias -Alias $Command
         } else {
             $cmd = $Command
         }

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -5,36 +5,36 @@ $script:InvokeCommandList = @{}
 .SYNOPSIS
 Set Command list with the key and command
 #>
-function Set-InvokeCommand{
+function Set-InvokeCommandAlias{
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$CommandKey,
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Alias,
         [Parameter(Mandatory,ValueFromPipeline,Position=1)][string]$Command
     )
     process {
-        if ($PSCmdlet.ShouldProcess("CommandList", "Set $CommandKey = $Command")) {
-            $InvokeCommandList[$CommandKey] = $Command
+        if ($PSCmdlet.ShouldProcess("CommandList", "Set $Alias = $Command")) {
+            $InvokeCommandList[$Alias] = $Command
         }
     }
-} Export-ModuleMember -Function Set-InvokeCommand
+} Export-ModuleMember -Function Set-InvokeCommandAlias
 
-function Test-InvokeCommand{
+function Test-InvokeCommandAlias{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$CommandKey
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Alias
     )
     process {
-        return $InvokeCommandList.ContainsKey($CommandKey)
+        return $InvokeCommandList.ContainsKey($Alias)
     }
 }
 
-function Get-InvokeCommand{
+function Get-InvokeCommandAlias{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$CommandKey
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Alias
     )
     process {
-        return $InvokeCommandList[$CommandKey]
+        return $InvokeCommandList[$Alias]
     }
 }
 
@@ -42,7 +42,7 @@ function Get-InvokeCommand{
 .SYNOPSIS
 Reset Command list
 #>
-function Reset-InvokeCommand{
+function Reset-InvokeCommandAlias{
     [CmdletBinding(SupportsShouldProcess)]
     param()
     process {
@@ -53,7 +53,7 @@ function Reset-InvokeCommand{
         "$InvokeCommandList" | Write-Verbose
 
     }
-} Export-ModuleMember -Function Reset-InvokeCommand
+} Export-ModuleMember -Function Reset-InvokeCommandAlias
 
 # Initilize $InvokeCommandList
-Reset-InvokeCommand
+Reset-InvokeCommandAlias

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -1,11 +1,11 @@
 
-$script:MockInvokeCommands = @{}
+$script:InvokeCommandList = @{}
 
 <#
 .SYNOPSIS
 Set Command list with the key and command
 #>
-function Set-MockInvokeCommand{
+function Set-InvokeCommand{
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$CommandKey,
@@ -13,28 +13,28 @@ function Set-MockInvokeCommand{
     )
     process {
         if ($PSCmdlet.ShouldProcess("CommandList", "Set $CommandKey = $Command")) {
-            $MockInvokeCommands[$CommandKey] = $Command
+            $InvokeCommandList[$CommandKey] = $Command
         }
     }
-} Export-ModuleMember -Function Set-MockInvokeCommand
+} Export-ModuleMember -Function Set-InvokeCommand
 
-function Test-MockInvokeCommand{
+function Test-InvokeCommand{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$CommandKey
     )
     process {
-        return $MockInvokeCommands.ContainsKey($CommandKey)
+        return $InvokeCommandList.ContainsKey($CommandKey)
     }
 }
 
-function Get-MockInvokeCommand{
+function Get-InvokeCommand{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$CommandKey
     )
     process {
-        return $MockInvokeCommands[$CommandKey]
+        return $InvokeCommandList[$CommandKey]
     }
 }
 
@@ -42,18 +42,18 @@ function Get-MockInvokeCommand{
 .SYNOPSIS
 Reset Command list
 #>
-function Reset-MockInvokeCommand{
+function Reset-InvokeCommand{
     [CmdletBinding(SupportsShouldProcess)]
     param()
     process {
         if ($PSCmdlet.ShouldProcess("CommandList", "Reset")) {
-            $MockInvokeCommands = @{}
+            $InvokeCommandList = @{}
         }
 
-        "$MockInvokeCommands" | Write-Verbose
+        "$InvokeCommandList" | Write-Verbose
 
     }
-} Export-ModuleMember -Function Reset-MockInvokeCommand
+} Export-ModuleMember -Function Reset-InvokeCommand
 
-# Initilize $MockInvokeCommands
-Reset-MockInvokeCommand
+# Initilize $InvokeCommandList
+Reset-InvokeCommand

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -28,13 +28,21 @@ function Test-InvokeCommandAlias{
     }
 }
 
-function Get-InvokeCommandAlias{
+function Resolve-InvokeCommandAlias{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Alias
     )
     process {
-        return $InvokeCommandList[$Alias]
+        if(Test-InvokeCommandAlias -Alias $Alias){
+            $cmd = $InvokeCommandList[$Alias]
+            # Recursive just in case we have mock the command behind the alias
+            $cmd = Resolve-InvokeCommandAlias -Alias $cmd
+        } else {
+            $cmd = $Alias
+        }
+
+        return $cmd
     }
 }
 


### PR DESCRIPTION
Allow to set command aliases to work with 

1. Centralize all commands onf an opp in a single place makin gthe app call based on aliases
2. Mock commands for testing setting aliases as the command to Mock

Fixes #18