### PR TITLE
Late resolve command to allow full command Mocks

### DIFF
--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -16,6 +16,9 @@ function Build-ScriptBlock{
             }
         }
 
+        # Resolve again checking for full command mocks
+        $cmd = Resolve-InvokeCommandAlias -Alias $cmd
+
         $ScriptBlock = [ScriptBlock]::Create($cmd)
 
         return $ScriptBlock

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -18,8 +18,13 @@ function Set-InvokeCommandAlias{
     }
 } Export-ModuleMember -Function Set-InvokeCommandAlias
 
+<#
+.SYNOPSIS
+Get the Command list active in the module
+#>
 function Get-InvokeCommandAlias{
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
+    [OutputType([hashtable])]
     param()
 
     if($script:InvokeCommandList -eq $null -or $script:InvokeCommandList.Count -eq 0){


### PR DESCRIPTION
If we want to mock a full command from test it's not possible if we are using alias and parameters in the module.

Calling reolve just before scriptblock allows to mock through alias a full command, parameters included.