### PR TITLE
refactor build-scriptblock

### DIFF
--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -1,6 +1,6 @@
-function Build-ScriptBlock{
+function Build-Command{
     [CmdletBinding()]
-    [OutputType([ScriptBlock])]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Command,
         [Parameter()][hashtable]$Parameters
@@ -19,9 +19,17 @@ function Build-ScriptBlock{
         # Resolve again checking for full command mocks
         $cmd = Resolve-InvokeCommandAlias -Alias $cmd
 
-        $ScriptBlock = [ScriptBlock]::Create($cmd)
-
-        return $ScriptBlock
+        return $cmd
     }
 }
 
+function New-ScriptBlock{
+    [CmdletBinding()]
+    [OutputType([ScriptBlock])]
+    param(
+        [Parameter(Mandatory,Position=0)][string]$Command
+    )
+    $ScriptBlock = [ScriptBlock]::Create($Command)
+
+    return $ScriptBlock
+}

--- a/public/Invoke-MyCommand.ps1
+++ b/public/Invoke-MyCommand.ps1
@@ -22,7 +22,9 @@ function Invoke-MyCommand {
 
     process{
 
-        $scriptBlock = Build-ScriptBlock -Command $Command -Parameters $Parameters
+        $cmd = Build-Command -Command $Command -Parameters $Parameters
+
+        $scriptBlock = New-ScriptBlock -Command $cmd
 
         if ($PSCmdlet.ShouldProcess("Target", $command)) {
 

--- a/public/Invoke-MyCommandAsync.ps1
+++ b/public/Invoke-MyCommandAsync.ps1
@@ -29,7 +29,9 @@ function Invoke-MyCommandAsync {
 
         $cmds | ForEach-Object {
 
-            $scriptBlock  = Build-ScriptBlock -Command $_ -Parameters $Parameters
+            $cmd = Build-Command -Command $_ -Parameters $Parameters
+
+            $scriptBlock = New-ScriptBlock -Command $cmd
 
             if ($PSCmdlet.ShouldProcess("Target", "Operation")) {
                 $job = Start-Job -ScriptBlock $scriptBlock

--- a/public/Start-MyJob.ps1
+++ b/public/Start-MyJob.ps1
@@ -17,7 +17,9 @@ function Start-MyJob{
     )
     process {
 
-        $scriptBlock  = Build-ScriptBlock -Command $Command -Parameters $Parameters
+        $cmd = Build-Command -Command $Command -Parameters $Parameters
+
+        $scriptBlock = New-ScriptBlock -Command $cmd
 
         if ($PSCmdlet.ShouldProcess("Target", "Operation")) {
             $job = Start-Job -ScriptBlock $scriptBlock


### PR DESCRIPTION
When debugging having the build of the command and the creation of te script block on different functions makes it much easier.

Split in two functions.