### PR TITLE
Set module sandbox mode to avoid calls to certain commands

### DIFF
--- a/InvokeHelperTest/public/InvokeCommandList.test.ps1
+++ b/InvokeHelperTest/public/InvokeCommandList.test.ps1
@@ -5,8 +5,8 @@ function InvokeHelperTest_InvokeCommandAlias_Get{
 
     $result = Get-InvokeCommandAlias
 
-    Assert-AreEqual -Expected 'echo "this is a sample command"' -Presented $result["commandAlias"]
-    Assert-AreEqual -Expected 'echo "this is a sample command2"' -Presented $result["commandAlias2"]
+    Assert-AreEqual -Expected 'echo "this is a sample command"' -Presented $result["commandAlias"].Command
+    Assert-AreEqual -Expected 'echo "this is a sample command2"' -Presented $result["commandAlias2"].Command
 }
 
 function InvokeHelperTest_InvokeCommandAlias_Reset{
@@ -20,8 +20,8 @@ function InvokeHelperTest_InvokeCommandAlias_Reset{
     Set-InvokeCommandAlias -Alias "commandAlias2" -Command 'echo "this is a sample command2"'
 
     $result = Get-InvokeCommandAlias
-    Assert-AreEqual -Expected 'echo "this is a sample command"' -Presented $result["commandAlias"]
-    Assert-AreEqual -Expected 'echo "this is a sample command2"' -Presented $result["commandAlias2"]
+    Assert-AreEqual -Expected 'echo "this is a sample command"' -Presented $result["commandAlias"].Command
+    Assert-AreEqual -Expected 'echo "this is a sample command2"' -Presented $result["commandAlias2"].Command
 
     Reset-InvokeCommandAlias
     $result = Get-InvokeCommandAlias

--- a/InvokeHelperTest/public/InvokeCommandList.test.ps1
+++ b/InvokeHelperTest/public/InvokeCommandList.test.ps1
@@ -3,7 +3,7 @@ function InvokeHelperTest_InvokeCommandAlias_Get{
     Set-InvokeCommandAlias -Alias "commandAlias" -Command 'echo "this is a sample command"'
     Set-InvokeCommandAlias -Alias "commandAlias2" -Command 'echo "this is a sample command2"'
 
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
 
     Assert-AreEqual -Expected 'echo "this is a sample command"' -Presented $result["commandAlias"].Command
     Assert-AreEqual -Expected 'echo "this is a sample command2"' -Presented $result["commandAlias2"].Command
@@ -13,25 +13,25 @@ function InvokeHelperTest_InvokeCommandAlias_Reset{
     
     Reset-InvokeCommandAlias
 
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
     Assert-IsNull -Object $result
     
     Set-InvokeCommandAlias -Alias "commandAlias" -Command 'echo "this is a sample command"'
     Set-InvokeCommandAlias -Alias "commandAlias2" -Command 'echo "this is a sample command2"'
 
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
     Assert-AreEqual -Expected 'echo "this is a sample command"' -Presented $result["commandAlias"].Command
     Assert-AreEqual -Expected 'echo "this is a sample command2"' -Presented $result["commandAlias2"].Command
 
     Reset-InvokeCommandAlias
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
     Assert-IsNull -Object $result
 }
 
 function InvokeHelperTest_InvokeCommandAlias_Reset_WithTag{
     Reset-InvokeCommandAlias
 
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
     Assert-IsNull -Object $result
 
     Set-InvokeCommandAlias -Alias "commandAlias11" -Command 'echo "this is a sample command11"' -Tag Mock1
@@ -39,7 +39,7 @@ function InvokeHelperTest_InvokeCommandAlias_Reset_WithTag{
     Set-InvokeCommandAlias -Alias "commandAlias12" -Command 'echo "this is a sample command12"' -Tag Mock1
     Set-InvokeCommandAlias -Alias "commandAlias22" -Command 'echo "this is a sample command22"' -Tag Mock2
     
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
 
     Assert-Count -Expected 4 -Presented $result
     Assert-AreEqual -Expected 'echo "this is a sample command11"' -Presented $result["commandAlias11"].Command
@@ -50,7 +50,7 @@ function InvokeHelperTest_InvokeCommandAlias_Reset_WithTag{
 
     Reset-InvokeCommandAlias -Tag Mock1
 
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
 
     Assert-Count -Expected 2 -Presented $result
     Assert-AreEqual -Expected 'echo "this is a sample command21"' -Presented $result["commandAlias21"].Command
@@ -66,7 +66,7 @@ function InvokeHelperTest_InvokeCommandAlias_Enable_Disable{
 
     Disable-InvokeCommandAlias -Tag Mock1
 
-    $result = Get-InvokeCommandAlias
+    $result = Get-InvokeCommandAliasList
 
     Assert-IsFalse -Condition $result.commandAlias1.Enabled
     Assert-IsFalse -Condition $result.commandAlias3.Enabled
@@ -81,4 +81,91 @@ function InvokeHelperTest_InvokeCommandAlias_Enable_Disable{
     
     Assert-IsTrue -Condition $result.commandAlias2.Enabled
     Assert-IsTrue -Condition $result.commandAlias4.Enabled
+}
+
+function InvokeHelperTest_InvokeCommandAlias_Invoke_Enable_Disable{
+
+    $text1 = "this is a sample command 1"
+    $text2 = "this is a sample command 2"
+
+    Set-InvokeCommandAlias -Alias "commandAlias1" -Command "echo $text1" -Tag Mock1
+    Set-InvokeCommandAlias -Alias "commandAlias2" -Command "echo $text2" -Tag Mock2
+
+    $result = Invoke-MyCommand -Command "commandAlias1"
+    Assert-AreEqual -Expected $text1 -Presented $result
+
+    $result = Invoke-MyCommand -Command "commandAlias2"
+    Assert-AreEqual -Expected $text2 -Presented $result
+
+    Disable-InvokeCommandAlias -Tag Mock1
+
+    $hasthrow = $false
+    try{
+        $result = Invoke-MyCommand -Command "commandAlias1"
+    } catch {
+        $hasthrow = $true
+    }
+    Assert-IsTrue -Condition $hasthrow
+
+    $result = Invoke-MyCommand -Command "commandAlias2"
+    Assert-AreEqual -Expected $text2 -Presented $result
+
+    Enable-InvokeCommandAlias -Tag Mock1
+
+    $result = Invoke-MyCommand -Command "commandAlias1"
+    Assert-AreEqual -Expected $text1 -Presented $result
+}
+
+function InvokeHelperTest_InvokeCommandAlias_Invoke_Mock_Disabled{
+
+    $text1 = "this is a sample command 1"
+    $text2 = "this is a sample command 2"
+    $text1Mock = "this is a sample command 1 Mock"
+    $text2Mock = "this is a sample command 2 Mock"
+
+    Set-InvokeCommandAlias -Alias "commandAlias1" -Command "echo $text1" -Tag "myModule"
+    Set-InvokeCommandAlias -Alias "commandAlias2" -Command "echo $text2" -Tag "myModule"
+    Set-InvokeCommandAlias -Alias "commandAlias3" -Command "echo $text3" -Tag "myModule"
+
+    Set-InvokeCommandAlias -Alias "echo $text1" -Command "echo $text1Mock" -Tag Mock1
+    Set-InvokeCommandAlias -Alias "echo $text2" -Command "echo $text2Mock" -Tag Mock2
+
+    # Disable all module commands
+    Disable-InvokeCommandAlias -Tag "myModule"
+
+    # Call module command with mock
+    $result = Invoke-MyCommand -Command "commandAlias1"
+    Assert-AreEqual -Expected $text1Mock -Presented $result
+
+    # Call module command with mock
+    $result = Invoke-MyCommand -Command "commandAlias2"
+    Assert-AreEqual -Expected $text2Mock -Presented $result
+
+    # Call module command with no mock
+    $hasthrow = $false
+    try{
+        $result = Invoke-MyCommand -Command "commandAlias3"
+    } catch {
+        $hasthrow = $true
+    }
+    Assert-IsTrue -Condition $hasthrow
+
+    # Disable a Mock tag
+    Disable-InvokeCommandAlias -Tag Mock1
+
+    # Call a module command with a disabled mock
+    $hasthrow = $false
+    try{
+        $result = Invoke-MyCommand -Command "commandAlias1"
+    } catch {
+        $hasthrow = $true
+    }
+    Assert-IsTrue -Condition $hasthrow
+
+    # enable a Mock tag
+    Enable-InvokeCommandAlias -Tag Mock1
+
+    # Call a module command with just enabled mock
+    $result = Invoke-MyCommand -Command "commandAlias1"
+    Assert-AreEqual -Expected $text1Mock -Presented $result
 }

--- a/InvokeHelperTest/public/InvokeCommandList.test.ps1
+++ b/InvokeHelperTest/public/InvokeCommandList.test.ps1
@@ -10,12 +10,12 @@ function InvokeHelperTest_InvokeCommandAlias_Get{
 }
 
 function InvokeHelperTest_InvokeCommandAlias_Reset{
-
+    
     Reset-InvokeCommandAlias
 
     $result = Get-InvokeCommandAlias
     Assert-IsNull -Object $result
-
+    
     Set-InvokeCommandAlias -Alias "commandAlias" -Command 'echo "this is a sample command"'
     Set-InvokeCommandAlias -Alias "commandAlias2" -Command 'echo "this is a sample command2"'
 
@@ -26,4 +26,33 @@ function InvokeHelperTest_InvokeCommandAlias_Reset{
     Reset-InvokeCommandAlias
     $result = Get-InvokeCommandAlias
     Assert-IsNull -Object $result
+}
+
+function InvokeHelperTest_InvokeCommandAlias_Reset_WithTag{
+    Reset-InvokeCommandAlias
+
+    $result = Get-InvokeCommandAlias
+    Assert-IsNull -Object $result
+
+    Set-InvokeCommandAlias -Alias "commandAlias11" -Command 'echo "this is a sample command11"' -Tag Mock1
+    Set-InvokeCommandAlias -Alias "commandAlias21" -Command 'echo "this is a sample command21"' -Tag Mock2
+    Set-InvokeCommandAlias -Alias "commandAlias12" -Command 'echo "this is a sample command12"' -Tag Mock1
+    Set-InvokeCommandAlias -Alias "commandAlias22" -Command 'echo "this is a sample command22"' -Tag Mock2
+    
+    $result = Get-InvokeCommandAlias
+
+    Assert-Count -Expected 4 -Presented $result
+    Assert-AreEqual -Expected 'echo "this is a sample command11"' -Presented $result["commandAlias11"].Command
+    Assert-AreEqual -Expected 'echo "this is a sample command21"' -Presented $result["commandAlias21"].Command
+    Assert-AreEqual -Expected 'echo "this is a sample command12"' -Presented $result["commandAlias12"].Command
+    Assert-AreEqual -Expected 'echo "this is a sample command22"' -Presented $result["commandAlias22"].Command
+
+
+    Reset-InvokeCommandAlias -Tag Mock1
+
+    $result = Get-InvokeCommandAlias
+
+    Assert-Count -Expected 2 -Presented $result
+    Assert-AreEqual -Expected 'echo "this is a sample command21"' -Presented $result["commandAlias21"].Command
+    Assert-AreEqual -Expected 'echo "this is a sample command22"' -Presented $result["commandAlias22"].Command
 }

--- a/InvokeHelperTest/public/InvokeCommandList.test.ps1
+++ b/InvokeHelperTest/public/InvokeCommandList.test.ps1
@@ -10,12 +10,12 @@ function InvokeHelperTest_InvokeCommandAlias_Get{
 }
 
 function InvokeHelperTest_InvokeCommandAlias_Reset{
-    
+
     Reset-InvokeCommandAlias
 
     $result = Get-InvokeCommandAliasList
     Assert-IsNull -Object $result
-    
+
     Set-InvokeCommandAlias -Alias "commandAlias" -Command 'echo "this is a sample command"'
     Set-InvokeCommandAlias -Alias "commandAlias2" -Command 'echo "this is a sample command2"'
 
@@ -38,7 +38,7 @@ function InvokeHelperTest_InvokeCommandAlias_Reset_WithTag{
     Set-InvokeCommandAlias -Alias "commandAlias21" -Command 'echo "this is a sample command21"' -Tag Mock2
     Set-InvokeCommandAlias -Alias "commandAlias12" -Command 'echo "this is a sample command12"' -Tag Mock1
     Set-InvokeCommandAlias -Alias "commandAlias22" -Command 'echo "this is a sample command22"' -Tag Mock2
-    
+
     $result = Get-InvokeCommandAliasList
 
     Assert-Count -Expected 4 -Presented $result
@@ -78,7 +78,7 @@ function InvokeHelperTest_InvokeCommandAlias_Enable_Disable{
 
     Assert-IsTrue -Condition $result.commandAlias1.Enabled
     Assert-IsTrue -Condition $result.commandAlias3.Enabled
-    
+
     Assert-IsTrue -Condition $result.commandAlias2.Enabled
     Assert-IsTrue -Condition $result.commandAlias4.Enabled
 }

--- a/InvokeHelperTest/public/InvokeCommandList.test.ps1
+++ b/InvokeHelperTest/public/InvokeCommandList.test.ps1
@@ -56,3 +56,29 @@ function InvokeHelperTest_InvokeCommandAlias_Reset_WithTag{
     Assert-AreEqual -Expected 'echo "this is a sample command21"' -Presented $result["commandAlias21"].Command
     Assert-AreEqual -Expected 'echo "this is a sample command22"' -Presented $result["commandAlias22"].Command
 }
+
+function InvokeHelperTest_InvokeCommandAlias_Enable_Disable{
+
+    Set-InvokeCommandAlias -Alias "commandAlias1" -Command "echo $text1" -Tag Mock1
+    Set-InvokeCommandAlias -Alias "commandAlias2" -Command "echo $text2" -Tag Mock2
+    Set-InvokeCommandAlias -Alias "commandAlias3" -Command "echo $text3" -Tag Mock1
+    Set-InvokeCommandAlias -Alias "commandAlias4" -Command "echo $text4" -Tag Mock2
+
+    Disable-InvokeCommandAlias -Tag Mock1
+
+    $result = Get-InvokeCommandAlias
+
+    Assert-IsFalse -Condition $result.commandAlias1.Enabled
+    Assert-IsFalse -Condition $result.commandAlias3.Enabled
+
+    Assert-IsTrue -Condition $result.commandAlias2.Enabled
+    Assert-IsTrue -Condition $result.commandAlias4.Enabled
+
+    Enable-InvokeCommandAlias -Tag Mock1
+
+    Assert-IsTrue -Condition $result.commandAlias1.Enabled
+    Assert-IsTrue -Condition $result.commandAlias3.Enabled
+    
+    Assert-IsTrue -Condition $result.commandAlias2.Enabled
+    Assert-IsTrue -Condition $result.commandAlias4.Enabled
+}

--- a/en-US/about_InvokeHelper.help.txt
+++ b/en-US/about_InvokeHelper.help.txt
@@ -36,7 +36,7 @@ SETTING THE COMMAND LIST
     ```
 
     ```powershell
-        > Get-InvokeCommandAlias                                           
+        > Get-InvokeCommandAliasList                                           
 
         Name                           Value
         ----                           -----

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -1,3 +1,35 @@
+# function Build-Command{
+#     [CmdletBinding()]
+#     [OutputType([string])]
+#     param(
+#         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Command,
+#         [Parameter()][hashtable]$Parameters
+#     )
+#     process {
+#         # Check if command is an alias. If not will return the command.
+#         $cmd1 = Resolve-InvokeCommandAlias -Alias $Command
+
+#         # Replace parameters on command
+#         $cmd1 = Update-CommandWithParameter -Command $cmd1 -Parameters $Parameters
+
+#         # Resolve again checking for full command mocks
+#         $cmd2 = Resolve-InvokeCommandAlias -Alias $cmd1
+
+#         if($cmd1 -ne $cmd2){
+#             # We have a command call mock
+#             # TODO: Allow while chards for mocking commands
+#             "We should check if we are in a sandbox mode" | Write-Verbose
+#         } else {
+#             # TODO: Confirm that we are not on a SandBox Mode
+#             "write a warning if we are not on a sandbox mode" | Write-Verbose
+#         }
+
+#         "Built Script Block: $cmd2" | Write-Verbose
+
+#         return $cmd2
+#     }
+# }
+
 function Build-Command{
     [CmdletBinding()]
     [OutputType([string])]
@@ -6,27 +38,32 @@ function Build-Command{
         [Parameter()][hashtable]$Parameters
     )
     process {
-        # Check if command is an alias. If not will return the command.
-        $cmd1 = Resolve-InvokeCommandAlias -Alias $Command
-
-        # Replace parameters on command
-        $cmd1 = Update-CommandWithParameter -Command $cmd1 -Parameters $Parameters
-
-        # Resolve again checking for full command mocks
-        $cmd2 = Resolve-InvokeCommandAlias -Alias $cmd1
-
-        if($cmd1 -ne $cmd2){
-            # We have a command call mock
-            # TODO: Allow while chards for mocking commands
-            "We should check if we are in a sandbox mode" | Write-Verbose
-        } else {
-            # TODO: Confirm that we are not on a SandBox Mode
-            "write a warning if we are not on a sandbox mode" | Write-Verbose
+        # Check if command is an alias. If not will return the command after updating for parameters
+        if(-Not (Test-InvokeCommandAlias -Alias $Command)){
+            $cmd = Update-CommandWithParameter -Command $Command -Parameters $Parameters
+            return $cmd
         }
 
-        "Built Script Block: $cmd2" | Write-Verbose
+        # Find the command for this alias
+        $alias = Find-InvokeCommandAlias -Alias $Command
 
-        return $cmd2
+        # Build the command with parameter
+        $cmd = Update-CommandWithParameter -Command $alias.Command -Parameters $Parameters
+
+        # Recurse to check for mocks
+        $mock = Find-InvokeCommandAlias -Alias $cmd
+        if($mock){
+            # We have a mock command
+            $cmd = $mock.Command
+            $alias = $mock
+        }
+
+        # Check if alias is disabled
+        if(! $alias.Enabled){
+            throw ("Alias command is disabled: $alias.Alias")
+         }
+
+         return $cmd
     }
 }
 

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -10,11 +10,7 @@ function Build-Command{
         $cmd1 = Resolve-InvokeCommandAlias -Alias $Command
 
         # Replace parameters on command
-        if($Parameters){
-            foreach($key in $Parameters.Keys){
-                $cmd1 = $cmd1.Replace("{"+$key+"}",$Parameters[$key])
-            }
-        }
+        $cmd1 = Update-CommandWithParameter -Command $cmd1 -Parameters $Parameters
 
         # Resolve again checking for full command mocks
         $cmd2 = Resolve-InvokeCommandAlias -Alias $cmd1
@@ -33,6 +29,26 @@ function Build-Command{
         return $cmd2
     }
 }
+
+function Update-CommandWithParameter{
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Command,
+        [Parameter()][hashtable]$Parameters
+    )
+    process {
+        # Replace parameters on command
+        if($Parameters){
+            foreach($key in $Parameters.Keys){
+                $Command = $Command.Replace("{"+$key+"}",$Parameters[$key])
+            }
+        }
+
+        return $Command
+    }
+}
+
 
 function New-ScriptBlock{
     [CmdletBinding()]

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -13,13 +13,13 @@ function Build-Command{
         }
 
         # Find the command for this alias
-        $alias = Find-InvokeCommandAlias -Alias $Command
+        $alias = Get-InvokeCommandAlias -Alias $Command
 
         # Build the command with parameter
         $cmd = Update-CommandWithParameter -Command $alias.Command -Parameters $Parameters
 
         # Recurse to check for mocks
-        $mock = Find-InvokeCommandAlias -Alias $cmd
+        $mock = Get-InvokeCommandAlias -Alias $cmd
         if($mock){
             # We have a mock command
             $cmd = $mock.Command

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -1,35 +1,3 @@
-# function Build-Command{
-#     [CmdletBinding()]
-#     [OutputType([string])]
-#     param(
-#         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Command,
-#         [Parameter()][hashtable]$Parameters
-#     )
-#     process {
-#         # Check if command is an alias. If not will return the command.
-#         $cmd1 = Resolve-InvokeCommandAlias -Alias $Command
-
-#         # Replace parameters on command
-#         $cmd1 = Update-CommandWithParameter -Command $cmd1 -Parameters $Parameters
-
-#         # Resolve again checking for full command mocks
-#         $cmd2 = Resolve-InvokeCommandAlias -Alias $cmd1
-
-#         if($cmd1 -ne $cmd2){
-#             # We have a command call mock
-#             # TODO: Allow while chards for mocking commands
-#             "We should check if we are in a sandbox mode" | Write-Verbose
-#         } else {
-#             # TODO: Confirm that we are not on a SandBox Mode
-#             "write a warning if we are not on a sandbox mode" | Write-Verbose
-#         }
-
-#         "Built Script Block: $cmd2" | Write-Verbose
-
-#         return $cmd2
-#     }
-# }
-
 function Build-Command{
     [CmdletBinding()]
     [OutputType([string])]

--- a/private/BuildCommand.ps1
+++ b/private/BuildCommand.ps1
@@ -7,19 +7,30 @@ function Build-Command{
     )
     process {
         # Check if command is an alias. If not will return the command.
-        $cmd = Resolve-InvokeCommandAlias -Alias $Command
+        $cmd1 = Resolve-InvokeCommandAlias -Alias $Command
 
         # Replace parameters on command
         if($Parameters){
             foreach($key in $Parameters.Keys){
-                $cmd = $cmd.Replace("{"+$key+"}",$Parameters[$key])
+                $cmd1 = $cmd1.Replace("{"+$key+"}",$Parameters[$key])
             }
         }
 
         # Resolve again checking for full command mocks
-        $cmd = Resolve-InvokeCommandAlias -Alias $cmd
+        $cmd2 = Resolve-InvokeCommandAlias -Alias $cmd1
 
-        return $cmd
+        if($cmd1 -ne $cmd2){
+            # We have a command call mock
+            # TODO: Allow while chards for mocking commands
+            "We should check if we are in a sandbox mode" | Write-Verbose
+        } else {
+            # TODO: Confirm that we are not on a SandBox Mode
+            "write a warning if we are not on a sandbox mode" | Write-Verbose
+        }
+
+        "Built Script Block: $cmd2" | Write-Verbose
+
+        return $cmd2
     }
 }
 

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -53,8 +53,6 @@ function Resolve-InvokeCommandAlias{
     process {
         if(Test-InvokeCommandAlias -Alias $Alias){
             $cmd = $InvokeCommandList[$Alias]
-            # Recursive just in case we have mock the command behind the alias
-            $cmd = Resolve-InvokeCommandAlias -Alias $cmd
         } else {
             $cmd = $Alias
         }

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -9,11 +9,16 @@ function Set-InvokeCommandAlias{
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Alias,
-        [Parameter(Mandatory,ValueFromPipeline,Position=1)][string]$Command
+        [Parameter(Mandatory,ValueFromPipeline,Position=1)][string]$Command,
+        [Parameter(Position=2)][string]$Tag
     )
     process {
         if ($PSCmdlet.ShouldProcess("CommandList", "Set $Alias = $Command")) {
-            $InvokeCommandList[$Alias] = $Command
+            $InvokeCommandList[$Alias] = [PSCustomObject]@{
+                Alias = $Alias
+                Command = $Command
+                Tag = $Tag
+            }
         }
     }
 } Export-ModuleMember -Function Set-InvokeCommandAlias
@@ -52,7 +57,7 @@ function Resolve-InvokeCommandAlias{
     )
     process {
         if(Test-InvokeCommandAlias -Alias $Alias){
-            $cmd = $InvokeCommandList[$Alias]
+            $cmd = $InvokeCommandList[$Alias].Command
         } else {
             $cmd = $Alias
         }

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -72,10 +72,21 @@ Reset Command list
 #>
 function Reset-InvokeCommandAlias{
     [CmdletBinding(SupportsShouldProcess)]
-    param()
+    param(
+        [Parameter()][string]$Tag
+    )
+    
     process {
+
+        $newInvokeCommandList = @{}
+
+        if(-Not [string]::IsNullOrWhiteSpace($Tag)){
+            $validKeys = $script:InvokeCommandList.Keys | Where-Object { $script:InvokeCommandList.$_.Tag -ne $Tag }
+            $validKeys | ForEach-Object { $newInvokeCommandList[$_] = $script:InvokeCommandList[$_] }
+        }
+
         if ($PSCmdlet.ShouldProcess("CommandList", "Reset")) {
-            $script:InvokeCommandList = @{}
+            $script:InvokeCommandList = $newInvokeCommandList
         }
 
         "$script:InvokeCommandList" | Write-Verbose

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -51,7 +51,7 @@ function Test-InvokeCommandAlias{
     }
 }
 
-function Find-InvokeCommandAlias{
+function Get-InvokeCommandAlias{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)][string]$Alias
@@ -69,7 +69,7 @@ function Reset-InvokeCommandAlias{
     param(
         [Parameter()][string]$Tag
     )
-    
+
     process {
 
         $newInvokeCommandList = @{}
@@ -91,6 +91,10 @@ function Reset-InvokeCommandAlias{
 # Initilize $InvokeCommandList
 Reset-InvokeCommandAlias
 
+<#
+.SYNOPSIS
+Disable a set of command alias by tag
+#>
 function Disable-InvokeCommandAlias{
     [CmdletBinding()]
     param(
@@ -104,6 +108,10 @@ function Disable-InvokeCommandAlias{
     }
 } Export-ModuleMember -Function Disable-InvokeCommandAlias
 
+<#
+.SYNOPSIS
+Enable a set of command alias by tag
+#>
 function Enable-InvokeCommandAlias{
     [CmdletBinding()]
     param(

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -18,6 +18,7 @@ function Set-InvokeCommandAlias{
                 Alias = $Alias
                 Command = $Command
                 Tag = $Tag
+                Enabled = $true
             }
         }
     }
@@ -96,3 +97,29 @@ function Reset-InvokeCommandAlias{
 
 # Initilize $InvokeCommandList
 Reset-InvokeCommandAlias
+
+function Disable-InvokeCommandAlias{
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$Tag
+    )
+
+    Foreach ($key in $InvokeCommandList.Keys) {
+        if($InvokeCommandList[$key].Tag -eq $Tag){
+            $InvokeCommandList[$key].Enabled = $false
+        }
+    }
+} Export-ModuleMember -Function Disable-InvokeCommandAlias
+
+function Enable-InvokeCommandAlias{
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$Tag
+    )
+
+    Foreach ($key in $InvokeCommandList.Keys) {
+        if($InvokeCommandList[$key].Tag -eq $Tag){
+            $InvokeCommandList[$key].Enabled = $true
+        }
+    }
+} Export-ModuleMember -Function Enable-InvokeCommandAlias

--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -28,7 +28,7 @@ function Set-InvokeCommandAlias{
 .SYNOPSIS
 Get the Command list active in the module
 #>
-function Get-InvokeCommandAlias{
+function Get-InvokeCommandAliasList{
     [CmdletBinding()]
     [OutputType([hashtable])]
     param()
@@ -39,7 +39,7 @@ function Get-InvokeCommandAlias{
         return $script:InvokeCommandList
     }
 
-} Export-ModuleMember -Function Get-InvokeCommandAlias
+} Export-ModuleMember -Function Get-InvokeCommandAliasList
 
 function Test-InvokeCommandAlias{
     [CmdletBinding()]
@@ -51,20 +51,13 @@ function Test-InvokeCommandAlias{
     }
 }
 
-function Resolve-InvokeCommandAlias{
+function Find-InvokeCommandAlias{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,ValueFromPipeline,Position=0)][string]$Alias
+        [Parameter(Mandatory,Position=0)][string]$Alias
     )
-    process {
-        if(Test-InvokeCommandAlias -Alias $Alias){
-            $cmd = $InvokeCommandList[$Alias].Command
-        } else {
-            $cmd = $Alias
-        }
 
-        return $cmd
-    }
+    return $InvokeCommandList[$Alias]
 }
 
 <#


### PR DESCRIPTION
Fixes #26

Allow to disable command alias based on tags to control the commads when running for sample tests and avoid calling the real functions and just allowing mocks alias.