### PR TITLE
Fix function typo

### DIFF
--- a/public/InvokeCommandList.ps1
+++ b/public/InvokeCommandList.ps1
@@ -101,7 +101,7 @@ function Disable-InvokeCommandAlias{
         [Parameter()][string]$Tag
     )
 
-    Set-IncokeCommandAlias -Tag $Tag -Value $false
+    Set-InvokeCommandTagEnabled -Tag $Tag -Value $false
 
 } Export-ModuleMember -Function Disable-InvokeCommandAlias
 
@@ -115,11 +115,11 @@ function Enable-InvokeCommandAlias{
         [Parameter()][string]$Tag
     )
 
-    Set-IncokeCommandAlias -Tag $Tag -Value $true
+    Set-InvokeCommandTagEnabled -Tag $Tag -Value $true
 
 } Export-ModuleMember -Function Enable-InvokeCommandAlias
 
-function Set-IncokeCommandAlias{
+function Set-InvokeCommandTagEnabled{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Tag,


### PR DESCRIPTION
This pull request fixes a function typo in the bub file. The function name "Set-IncokeCommandAlias" has been corrected to "Set-InvokeCommandTagEnabled".