### PR TITLE
Use Start-ThreadJob for asynchronous operations

### DIFF
--- a/InvokeHelperTest/public/Start-MyJob.test.ps1
+++ b/InvokeHelperTest/public/Start-MyJob.test.ps1
@@ -15,19 +15,17 @@ function InvokeHelperTest_JobInternal_Start{
 
 function InvokeHelperTest_JobInternal_Start_WhatIf{
     $jobs = @()
-    $jobs += Start-MyJob -Command "command to be called1" -WhatIf @InfoParameters
-    Assert-Contains -Expected "command to be called1" -Presented $infoVar
+    $jobs += Start-MyJob -Command "return 1" -WhatIf @InfoParameters
+    Assert-Contains -Expected "return 1" -Presented $infoVar
 
-    $jobs += Start-MyJob -Command "command to be called2" -WhatIf @InfoParameters
-    Assert-Contains -Expected "command to be called2" -Presented $infoVar
+    $jobs += Start-MyJob -Command "return 2" -WhatIf @InfoParameters
+    Assert-Contains -Expected "return 2" -Presented $infoVar
 
     $waited = Wait-Job -Job $jobs
 
     $result = Receive-Job -Job $waited
 
-    Assert-Count -Expected 2 -Presented $result
-    Assert-IsNull -Object $result[0]
-    Assert-IsNull -Object $result[1]
+    Assert-isnull -Object $result
 }
 
 function InvokeHelperTest_JobInternal_Start_MultiCall{

--- a/public/Invoke-MyCommandAsync.ps1
+++ b/public/Invoke-MyCommandAsync.ps1
@@ -34,10 +34,10 @@ function Invoke-MyCommandAsync {
             $scriptBlock = New-ScriptBlock -Command $cmd
 
             if ($PSCmdlet.ShouldProcess("Target", "Operation")) {
-                $job = Start-Job -ScriptBlock $scriptBlock
+                $job = Start-ThreadJob -ScriptBlock $scriptBlock
             } else {
                 Write-Information $scriptBlock
-                $job = Start-Job -ScriptBlock {$null}
+                $job = Start-ThreadJob -ScriptBlock {$null}
             }
 
             $jobs += $job

--- a/public/Start-MyJob.ps1
+++ b/public/Start-MyJob.ps1
@@ -22,10 +22,10 @@ function Start-MyJob{
         $scriptBlock = New-ScriptBlock -Command $cmd
 
         if ($PSCmdlet.ShouldProcess("Target", "Operation")) {
-            $job = Start-Job -ScriptBlock $scriptBlock
+            $job = Start-ThreadJob -ScriptBlock $scriptBlock
         } else {
             Write-Information $scriptBlock
-            $job = Start-Job -ScriptBlock {$null}
+            $job = Start-ThreadJob -ScriptBlock {$null}
         }
 
         return $job


### PR DESCRIPTION
Replace Start-Job with Start-ThreadJob in the Invoke-MyCommandAsync and Start-MyJob functions to improve performance and resource management during job execution.